### PR TITLE
Filepath error in Services/nginx

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
         ports:
             - 8080:80
         volumes:
-            - ./docker/nginx/default.conf:/etc/nginx/conf.d/default.conf
+            - ./docker/nginx/default.conf:/etc/nginx/conf.d/
         volumes_from:
             - php
 


### PR DESCRIPTION
Currently getting error on spin up to say that ./docker/nginx/default.conf is trying to mount a file to a folder.

The definition of the nginx services path to the nginx config file should be to the directory, and not explicitly name the file.  

Edited line 18 to remove "default.conf" from volume file path.

Tested succesfully on windows 8.1 environment.